### PR TITLE
Fix EnterDetails not call onDisappear()

### DIFF
--- a/Brisk iOS/Radar/EnterDetailsViewController.swift
+++ b/Brisk iOS/Radar/EnterDetailsViewController.swift
@@ -41,6 +41,12 @@ final class EnterDetailsViewController: UIViewController, StoryboardBacked {
 		center.addObserver(self, selector: #selector(EnterDetailsViewController.adjustForKeyboard(notification:)), name: Notification.Name.UIKeyboardWillChangeFrame, object: nil)
 	}
 
+    override func viewWillDisappear(_ animated: Bool) {
+        if placeholder.isEmpty ||
+            textView.text != placeholder {
+            onDisappear(textView.text)
+        }
+    }
 
 	// MARK: - Private Methods
 


### PR DESCRIPTION
I found that EnterDetailsViewController does not call onDisappear() when disappear. Fixed this, or the change will not pass back.