### PR TITLE
Fix RadarViewModel force unwarpping array.first crash

### DIFF
--- a/Brisk iOS/Radar/RadarViewModel.swift
+++ b/Brisk iOS/Radar/RadarViewModel.swift
@@ -22,7 +22,7 @@ extension RadarViewModel {
 
 	init(_ radar: Radar) {
 		product = radar.product
-		area = radar.area ?? Area.areas(for: product).first!
+		area = radar.area ?? Area.areas(for: product).first
 		classification = radar.classification
 		reproducibility = radar.reproducibility
 		title = radar.title

--- a/Brisk iOS/Radar/RadarViewModel.swift
+++ b/Brisk iOS/Radar/RadarViewModel.swift
@@ -22,7 +22,7 @@ extension RadarViewModel {
 
 	init(_ radar: Radar) {
 		product = radar.product
-		area = radar.area ?? Area.areas(for: product).first
+		area = radar.area
 		classification = radar.classification
 		reproducibility = radar.reproducibility
 		title = radar.title


### PR DESCRIPTION
Force unwarpping Area.areas(for: product).first! will result in: "Fatal error: Unexpectedly found nil while unwrapping an Optional value". Here RadarViewModel.area is optional, so no need for the "!".

You can replicate the crash with rdar://41816849