### PR TITLE
Fix localizable

### DIFF
--- a/Brisk iOS/App/StatusDisplay.swift
+++ b/Brisk iOS/App/StatusDisplay.swift
@@ -19,9 +19,9 @@ extension StatusDisplay where Self: UIViewController {
 		SVProgressHUD.showSuccess(withStatus: message)
 	}
 
-	func showError(title: String? = NSLocalizedString("Global.Error", comment: ""),
+	func showError(title: String? = Localizable.Global.error.localized,
 	               message: String,
-	               dismissButtonTitle: String? = NSLocalizedString("Global.Dismiss", comment: ""),
+	               dismissButtonTitle: String? = Localizable.Global.dismiss.localized,
 	               completion: (() -> Void)? = nil) {
 		let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
 		alert.addAction(UIAlertAction(title: dismissButtonTitle, style: .cancel, handler: nil))

--- a/Brisk iOS/Model/Localizable.swift
+++ b/Brisk iOS/Model/Localizable.swift
@@ -18,6 +18,11 @@ enum Localizable {
         case cancel     = "Global.Cancel"
     }
 
+    enum QuickAction: Localize, LocalizeRepresentable {
+        case newRadar           = "QuickAction.NewRadar"
+        case duplicateRadar     = "QuickAction.DuplicateRadar"
+    }
+
     enum Login {
         enum Error: Localize, LocalizeRepresentable {
             case invalidEmail   = "LoginError.InvalidEmail"

--- a/Brisk iOS/Model/QuickAction.swift
+++ b/Brisk iOS/Model/QuickAction.swift
@@ -13,7 +13,7 @@ public extension QuickAction {
             let icon = UIApplicationShortcutIcon(templateImageName: "Compose")
 
             return UIApplicationShortcutItem(type: "new-radar",
-                                             localizedTitle: NSLocalizedString("QuickAction.NewRadar", comment: ""),
+                                             localizedTitle: Localizable.QuickAction.newRadar.localized,
                                              localizedSubtitle: nil,
                                              icon: icon)
         }
@@ -22,7 +22,7 @@ public extension QuickAction {
             let icon = UIApplicationShortcutIcon(templateImageName: "Duplicate")
 
             return UIApplicationShortcutItem(type: "duplicate-radar",
-                                             localizedTitle: NSLocalizedString("QuickAction.DuplicateRadar", comment: ""),
+                                             localizedTitle: Localizable.QuickAction.duplicateRadar.localized,
                                              localizedSubtitle: nil,
                                              icon: icon)
         }

--- a/Brisk iOS/Radar/SubmitRadarDelegate.swift
+++ b/Brisk iOS/Radar/SubmitRadarDelegate.swift
@@ -32,13 +32,13 @@ final class SubmitRadarDelegate: APIDelegate {
 	func didPostToAppleRadar() {
 		display.hideLoading()
 		let delay = 3.0
-		display.showSuccess(message: NSLocalizedString("Radar.Post.Success", comment: ""), autoDismissAfter: delay)
+		display.showSuccess(message: Localizable.Radar.Post.success.localized, autoDismissAfter: delay)
 		finishHandler(true)
 	}
 
 	func didPostToOpenRadar() {
 		display.hideLoading()
-		display.showSuccess(message: NSLocalizedString("Radar.Post.Success", comment: ""), autoDismissAfter: 3.0)
+		display.showSuccess(message: Localizable.Radar.Post.success.localized, autoDismissAfter: 3.0)
 		finishHandler(false)
 	}
 

--- a/Brisk iOS/Radar/TwoFactorAuthentication.swift
+++ b/Brisk iOS/Radar/TwoFactorAuthentication.swift
@@ -15,7 +15,7 @@ final class TwoFactorAuthentication: TwoFactorAuthenticationHandler {
 	}
 
 	func askForCode(completion: @escaping (String) -> Void) {
-		let alert = UIAlertController(title: NSLocalizedString("Radar.TwoFactorAuth.Title", comment: ""), message: NSLocalizedString("Radar.TwoFactorAuth.Message", comment: ""), preferredStyle: .alert)
+		let alert = UIAlertController(title: Localizable.Radar.TwoFactor.title.localized, message: Localizable.Radar.TwoFactor.message.localized, preferredStyle: .alert)
 		alert.addTextField { (field) in
 			field.keyboardType = .numberPad
 			let bodyDescriptor = UIFontDescriptor.preferredFontDescriptor(withTextStyle: .body)
@@ -23,7 +23,7 @@ final class TwoFactorAuthentication: TwoFactorAuthenticationHandler {
 			field.autocorrectionType = .no
 			field.enablesReturnKeyAutomatically = true
 		}
-		alert.addAction(UIAlertAction(title: NSLocalizedString("Radar.TwoFactorAuth.Submit", comment: ""), style: .default, handler: { _ in
+		alert.addAction(UIAlertAction(title: Localizable.Radar.TwoFactor.submit.localized, style: .default, handler: { _ in
 			guard let field = alert.textFields?.first else { preconditionFailure() }
 			guard let text = field.text, text.isNotEmpty else {
 				alert.dismiss(animated: true) {

--- a/Brisk iOS/Resources/en.lproj/Localizable.strings
+++ b/Brisk iOS/Resources/en.lproj/Localizable.strings
@@ -46,6 +46,10 @@
 "Radar.Notes.Placeholder" = "Provide any additional information, such as references to related problems or workarounds";
 "Radar.Attachment" = "Attachment";
 "Radar.Attachment.NoAttachments" = "No attachments";
+"Radar.Post.Success" = "Done";
+"Radar.TwoFactorAuth.Title" = "Apple ID Verification Code";
+"Radar.TwoFactorAuth.Message" = "Enter two factor auth code";
+"Radar.TwoFactorAuth.Submit" = "Submit";
 
 
 // MARK: - Settings


### PR DESCRIPTION
I've found some strings are missing, added them myself. (They are obvious during the process of filing a radar with two factor auth, and let me think do you use the app yourself?) We can discuss the content of the strings.

Also, some messages still use NSLocalizedString() after #25. I've replaced them with Localizable.